### PR TITLE
Removed calls of the deprecated np.complex128

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # ide folders
 .idea
 .vscode
+.venv
 
 # python folders
 *.egg-info/

--- a/pyvolt/network.py
+++ b/pyvolt/network.py
@@ -95,8 +95,8 @@ class System():
         self.nodes = []
         self.branches = []
         self.breakers = []
-        self.Ymatrix = np.zeros([], dtype=np.complex)
-        self.Bmatrix = np.zeros([], dtype=np.complex)
+        self.Ymatrix = np.zeros([], dtype=np.complex128)
+        self.Bmatrix = np.zeros([], dtype=np.complex128)
 
     def get_node_by_uuid(self, node_uuid):
         for node in self.nodes:
@@ -344,8 +344,8 @@ class System():
     def Ymatrix_calc(self):
         self.reindex_nodes_list()
         nodes_num = self.get_nodes_num()
-        self.Ymatrix = np.zeros((nodes_num, nodes_num), dtype=np.complex)
-        self.Bmatrix = np.zeros((nodes_num, nodes_num), dtype=np.complex)
+        self.Ymatrix = np.zeros((nodes_num, nodes_num), dtype=np.complex128)
+        self.Bmatrix = np.zeros((nodes_num, nodes_num), dtype=np.complex128)
         for branch in self.branches:
             fr = branch.start_node.index
             to = branch.end_node.index

--- a/pyvolt/results.py
+++ b/pyvolt/results.py
@@ -258,7 +258,7 @@ class Results():
         get node voltages
         - if pu==True --> voltages are expressed as per-unit
         """
-        voltages = np.zeros(len(self.nodes), dtype=np.complex_)
+        voltages = np.zeros(len(self.nodes), dtype=np.complex128)
         if pu == True:
             for node in self.nodes:
                 voltages[node.topology_node.index] = node.voltage_pu
@@ -273,7 +273,6 @@ class Results():
         get branch powers
         - if pu==True --> branch powers are expressed as per-unit
         """
-        #branch_powers = np.zeros(len(self.branches), dtype=np.complex_)
         branch_powers = []
         if pu == True:
             for branch in self.branches:
@@ -289,7 +288,7 @@ class Results():
         get node currents
         - if pu==True --> voltages are expressed as per-unit
         """
-        Iinj = np.zeros(len(self.nodes), dtype=np.complex_)
+        Iinj = np.zeros(len(self.nodes), dtype=np.complex128)
         if pu == True:
             for node in self.nodes:
                 Iinj[node.topology_node.index] = node.current_pu
@@ -304,7 +303,7 @@ class Results():
         get node power
         - if pu==True --> voltages are expressed as per-unit
         """
-        Sinj = np.zeros(len(self.nodes), dtype=np.complex_)
+        Sinj = np.zeros(len(self.nodes), dtype=np.complex128)
         if pu == True:
             for node in self.nodes:
                 Sinj[node.topology_node.index] = node.power_pu
@@ -319,7 +318,7 @@ class Results():
         get branch currents
         - if pu==True --> voltages are expressed as per-unit
         """
-        I = np.zeros(len(self.branches), dtype=np.complex_)
+        I = np.zeros(len(self.branches), dtype=np.complex128)
         if pu == True:
             for branch_idx in range(len(self.branches)):
                 I[branch_idx] = self.branches[branch_idx].current_pu
@@ -334,7 +333,7 @@ class Results():
         get complex Power flow at branch, measured at initial node
         - if pu==True --> voltages are expressed as per-unit
         """
-        S1 = np.zeros(len(self.branches), dtype=np.complex_)
+        S1 = np.zeros(len(self.branches), dtype=np.complex128)
         if pu == True:
             for branch_idx in range(len(self.branches)):
                 S1[branch_idx] = self.branches[branch_idx].power_pu
@@ -349,7 +348,7 @@ class Results():
         get complex Power flow at branch, measured at final node
         - if pu==True --> voltages are expressed as per-unit
         """
-        S2 = np.zeros(len(self.branches), dtype=np.complex_)
+        S2 = np.zeros(len(self.branches), dtype=np.complex128)
         if pu == True:
             for branch_idx in range(len(self.branches)):
                 S2[branch_idx] = self.branches[branch_idx].power2_pu


### PR DESCRIPTION
By changing np.complex to np.complex128, i magically raised the required version of numpy from 1.22.4 to 2.0.2 , removing the dependency conflict between pandas and pyvolt ( over numpy )